### PR TITLE
Add optional GUI mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Scientific Calculator
 
-This repository provides a simple command-line scientific calculator written in Python.
+This repository provides a simple scientific calculator written in Python. It can run
+either as a command-line tool or with a small graphical interface built using Tkinter.
 
 ## Usage
 
@@ -10,4 +11,7 @@ Run the calculator with Python:
 python calculator.py
 ```
 
-Type mathematical expressions using operators (`+`, `-`, `*`, `/`, `**`) and functions from Python's `math` module, such as `sin`, `cos`, `log`, etc. Enter `quit` or `exit` to close the program.
+When started, the program will ask whether you want the command-line or UI version.
+Type mathematical expressions using operators (`+`, `-`, `*`, `/`, `**`) and
+functions from Python's `math` module, such as `sin`, `cos`, `log`, etc.
+Enter `quit` or `exit` to close the command-line mode or the UI window.

--- a/calculator.py
+++ b/calculator.py
@@ -1,4 +1,5 @@
 import math
+import tkinter as tk
 
 allowed_names = {k: getattr(math, k) for k in dir(math) if not k.startswith("_")}
 
@@ -11,7 +12,8 @@ def evaluate(expr: str):
         raise ValueError(f"Invalid expression {expr}: {e}")
 
 
-def main():
+def cli_mode():
+    """Run the traditional command-line calculator."""
     print("Scientific Calculator. Type 'quit' to exit.")
     while True:
         try:
@@ -27,6 +29,48 @@ def main():
             print(result)
         except Exception as e:
             print("Error:", e)
+
+
+def ui_mode():
+    """Launch a simple Tkinter based UI for the calculator."""
+    root = tk.Tk()
+    root.title("Scientific Calculator")
+
+    entry = tk.Entry(root, width=40)
+    entry.pack(padx=10, pady=10)
+
+    result_var = tk.StringVar()
+    result_label = tk.Label(root, textvariable=result_var)
+    result_label.pack(padx=10, pady=(0, 10))
+
+    def evaluate_expr(event=None):
+        expr = entry.get()
+        if expr.lower() in {"quit", "exit"}:
+            root.destroy()
+            return
+        if not expr.strip():
+            result_var.set("")
+            return
+        try:
+            result = evaluate(expr)
+            result_var.set(str(result))
+        except Exception as e:
+            result_var.set(f"Error: {e}")
+
+    calculate_btn = tk.Button(root, text="Calculate", command=evaluate_expr)
+    calculate_btn.pack(padx=10, pady=(0, 10))
+
+    entry.bind("<Return>", evaluate_expr)
+
+    root.mainloop()
+
+
+def main():
+    mode = input("Select mode - 'cli' for command line or 'ui' for graphical (default cli): ").strip().lower()
+    if mode == "ui":
+        ui_mode()
+    else:
+        cli_mode()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- convert calculator so it can run in CLI or GUI mode
- update README with new usage instructions

## Testing
- `python -m pytest -q`
- `python calculator.py <<'EOF'
cli
1+2
quit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6870efaa75c083329f18afac72d1f8d4